### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.20</version>
+					<version>3.5.2</version>
 					<configuration>
 						<argLine>-Dfile.encoding=UTF-8</argLine>
 					</configuration>
@@ -48,12 +48,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>2.10.4</version>
+					<version>3.11.2</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-release-plugin</artifactId>
-					<version>2.5.3</version>
+					<version>3.1.1</version>
 					<configuration>
 						<tagNameFormat>@{project.version}</tagNameFormat>
 					</configuration>
@@ -61,32 +61,32 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-clean-plugin</artifactId>
-					<version>3.0.0</version>
+					<version>3.4.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-resources-plugin</artifactId>
-					<version>2.7</version>
+					<version>3.3.1</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.3</version>
+					<version>3.13.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-war-plugin</artifactId>
-					<version>2.8.2</version>
+					<version>3.4.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-ear-plugin</artifactId>
-					<version>2.10.1</version>
+					<version>3.3.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>2.6</version>
+					<version>3.4.2</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -96,12 +96,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-install-plugin</artifactId>
-					<version>2.5.2</version>
+					<version>3.1.3</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-deploy-plugin</artifactId>
-					<version>2.8.2</version>
+					<version>3.1.3</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -117,7 +117,7 @@
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>build-helper-maven-plugin</artifactId>
-					<version>1.9</version>
+					<version>3.6.0</version>
 				</plugin>
 				<plugin>
 					<groupId>com.amashchenko.maven.plugin</groupId>
@@ -150,7 +150,12 @@
 				<plugin>
 					<groupId>com.mycila</groupId>
 					<artifactId>license-maven-plugin</artifactId>
-					<version>3.0.rc1</version>
+					<version>4.6</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-source-plugin</artifactId>
+					<version>3.3.1</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -180,7 +185,7 @@
 						</goals>
 						<configuration>
 							<!-- disable checking -->
-							<additionalparam>-Xdoclint:none</additionalparam>
+							<doclint>none</doclint>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
## Summary
- Update all Maven plugin dependencies to their latest versions
- Add maven-source-plugin version to pluginManagement
- Update javadoc plugin configuration to use new doclint parameter

## Changes
- maven-surefire-plugin: 2.20 → 3.5.2
- maven-javadoc-plugin: 2.10.4 → 3.11.2
- maven-release-plugin: 2.5.3 → 3.1.1
- maven-clean-plugin: 3.0.0 → 3.4.0
- maven-resources-plugin: 2.7 → 3.3.1
- maven-compiler-plugin: 3.3 → 3.13.0
- maven-war-plugin: 2.8.2 → 3.4.0
- maven-ear-plugin: 2.10.1 → 3.3.0
- maven-jar-plugin: 2.6 → 3.4.2
- maven-install-plugin: 2.5.2 → 3.1.3
- maven-deploy-plugin: 2.8.2 → 3.1.3
- build-helper-maven-plugin: 1.9 → 3.6.0
- license-maven-plugin: 3.0.rc1 → 4.6
- Added maven-source-plugin: 3.3.1 to pluginManagement
- Updated javadoc additionalparam to use doclint configuration

Fixes #5