### PR TITLE
Add status badges and update version in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Parent OSS
 
+[![CI](https://github.com/dataliquid/parent-oss/actions/workflows/ci.yml/badge.svg)](https://github.com/dataliquid/parent-oss/actions/workflows/ci.yml)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.dataliquid/parent-oss/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.dataliquid/parent-oss)
+
 Parent POM for open source projects.
 
 ## Overview
@@ -14,7 +17,7 @@ To use this parent POM in your project, add the following to your `pom.xml`:
 <parent>
     <groupId>com.dataliquid</groupId>
     <artifactId>parent-oss</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.0</version>
 </parent>
 ```
 


### PR DESCRIPTION
## Summary
- Added CI build status and Maven Central version badges to README
- Updated parent POM version in usage example to reflect latest release

## Changes
- Added GitHub Actions CI badge showing build status
- Added Maven Central badge displaying latest available version
- Updated version from 1.0.0 to 2.0.0 in the usage example

## Motivation
These badges provide immediate visibility of the project's build status and latest available version, making it easier for users to:
- Check if the build is passing before using the parent POM
- See the latest version available on Maven Central
- Have accurate version information in the documentation

Fixes #9