### PR TITLE
Add permissions to Gitflow workflows

### DIFF
--- a/.github/workflows/gitflow-hotfix.yml
+++ b/.github/workflows/gitflow-hotfix.yml
@@ -15,6 +15,10 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   hotfix:
     uses: dataliquid/github-actions/.github/workflows/gitflow-hotfix.yml@1.0.0

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -15,6 +15,10 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     uses: dataliquid/github-actions/.github/workflows/gitflow-release.yml@1.0.0


### PR DESCRIPTION
## Summary
- Add permissions to existing Gitflow workflows for proper operation
- Add `contents: write` for branch and tag operations
- Add `pull-requests: write` for PR operations

## Why this change is needed
The previous PR #11 was merged but the workflows need explicit permissions to:
- Create and push branches
- Create and push tags
- Potentially create or modify pull requests

## Test plan
- [ ] Verify workflows can create branches with release-start/hotfix-start
- [ ] Verify workflows can push changes and tags with release-finish/hotfix-finish
- [ ] Ensure no permission errors occur during workflow execution