### PR TITLE
Hotfix: Exclude build directory from PMD analysis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,6 +333,9 @@
 							</rulesets>
 							<verbose>true</verbose>
 							<printFailingErrors>true</printFailingErrors>
+							<excludeRoots>
+								<excludeRoot>${project.build.directory}</excludeRoot>
+							</excludeRoots>
 						</configuration>
 						<executions>
 							<execution>


### PR DESCRIPTION
## Summary
- Excludes the entire build directory from PMD analysis to prevent false positives from generated code

## Problem
PMD was analyzing auto-generated files (like Maven plugin HelpMojo classes) in the build directory, causing false positive violations in projects that use parent-oss.

## Solution
Added `excludeRoots` configuration to the PMD plugin in the QA profile to exclude `${project.build.directory}` from analysis.

## Test plan
- [ ] Verify PMD still runs on source code
- [ ] Verify generated files are excluded from PMD analysis
- [ ] Test with projects that generate code (e.g., Maven plugins)